### PR TITLE
Fix Issue #4

### DIFF
--- a/Dates/XLDate.cpp
+++ b/Dates/XLDate.cpp
@@ -301,7 +301,7 @@ namespace Dates
 		{
 			serialDate_ = 60;
 		}
-		else if (!date_.ok() || (year() - 1900) > 199)
+		else if (!date_.ok() || (year() - 1900) > 299)
 		{
 			return false;
 		}


### PR DESCRIPTION
In `bool XLDate::dateToSerial_()`, the `(year() - 1900) >` inequality was changed from 199 to 299 days, per Excel standard.